### PR TITLE
[Spot] add settlement processing logic;

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,4 +11,7 @@ pub enum ContractError {
 
     #[error("Invalid order data")]
     InvalidOrderData(),
+
+    #[error("Invalid settlement: {0}")]
+    InvalidSettlement(String),
 }

--- a/src/order.rs
+++ b/src/order.rs
@@ -16,3 +16,7 @@ pub fn save_order(storage: &mut dyn Storage, order: &OrderState) {
 pub fn get_order(storage: &dyn Storage, id: u64) -> Result<OrderState, cosmwasm_std::StdError> {
     ORDER.load(storage, id)
 }
+
+pub fn delete_order(storage: &mut dyn Storage, id: u64) {
+    ORDER.remove(storage, id)
+}

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -3,3 +3,5 @@ mod mock_querier;
 mod order_ut;
 mod state_ut;
 mod tests;
+mod utils;
+mod utils_ut;

--- a/src/testing/order_ut.rs
+++ b/src/testing/order_ut.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::Decimal;
 
-use crate::order::{get_order, save_order};
+use crate::order::{delete_order, get_order, save_order};
 use crate::state::{Order, OrderType, PositionDirection, PositionEffect};
 use crate::testing::mock_querier::mock_dependencies;
 
@@ -26,4 +26,27 @@ fn test_save_get_order() {
     save_order(deps.as_mut().storage, &order);
     let stored_order = get_order(deps.as_ref().storage, 0).unwrap();
     assert_eq!(order, stored_order);
+}
+
+#[test]
+fn test_delete_order() {
+    let mut deps = mock_dependencies(&vec![]);
+    let order = Order {
+        id: 0,
+        account: TEST_ACCOUNT.to_owned(),
+        price_denom: TEST_PRICE_DENOM.to_owned(),
+        asset_denom: TEST_ASSET_DENOM.to_owned(),
+        price: Decimal::from_atomics(123u128, 0).unwrap(),
+        quantity: Decimal::from_atomics(456u128, 0).unwrap(),
+        remaining_quantity: Decimal::from_atomics(456u128, 0).unwrap(),
+        direction: PositionDirection::Long,
+        effect: PositionEffect::Open,
+        order_type: OrderType::Limit,
+    };
+    save_order(deps.as_mut().storage, &order);
+    delete_order(deps.as_mut().storage, 0);
+    match get_order(deps.as_ref().storage, 0) {
+        Ok(_) => panic!("Order should have been deleted"),
+        Err(_) => (),
+    };
 }

--- a/src/testing/state_ut.rs
+++ b/src/testing/state_ut.rs
@@ -1,22 +1,13 @@
 use cosmwasm_std::Decimal;
 
-use crate::state::{Order, OrderPlacement, OrderType, PositionDirection, PositionEffect};
+use crate::{
+    state::{Order, OrderType, PositionDirection, PositionEffect},
+    testing::utils::vanilla_order_placement,
+};
 
 #[test]
 fn test_order_placement_to_order() {
-    let order_placement = OrderPlacement {
-        id: 0,
-        status: 0,
-        account: "test".to_owned(),
-        contract_address: "test".to_owned(),
-        price_denom: "usei".to_owned(),
-        asset_denom: "uatom".to_owned(),
-        price: Decimal::one(),
-        quantity: Decimal::one(),
-        order_type: 0,
-        position_direction: 0,
-        data: "{\"position_effect\":\"Open\"}".to_owned(),
-    };
+    let order_placement = vanilla_order_placement();
     let expected_order = Order {
         id: 0,
         account: "test".to_owned(),

--- a/src/testing/utils.rs
+++ b/src/testing/utils.rs
@@ -1,0 +1,32 @@
+use crate::state::{OrderPlacement, OrderType, PositionDirection, SettlementEntry};
+use cosmwasm_std::Decimal;
+
+pub fn vanilla_order_placement() -> OrderPlacement {
+    OrderPlacement {
+        id: 0,
+        status: 0,
+        account: "test".to_owned(),
+        contract_address: "test".to_owned(),
+        price_denom: "usei".to_owned(),
+        asset_denom: "uatom".to_owned(),
+        price: Decimal::one(),
+        quantity: Decimal::one(),
+        order_type: 0,
+        position_direction: 0,
+        data: "{\"position_effect\":\"Open\"}".to_owned(),
+    }
+}
+
+pub fn vanilla_settlement_entry() -> SettlementEntry {
+    SettlementEntry {
+        account: "test".to_owned(),
+        price_denom: "usei".to_owned(),
+        asset_denom: "uatom".to_owned(),
+        quantity: Decimal::one(),
+        execution_cost_or_proceed: Decimal::one(),
+        expected_cost_or_proceed: Decimal::one(),
+        position_direction: PositionDirection::Long,
+        order_type: OrderType::Limit,
+        order_id: 0,
+    }
+}

--- a/src/testing/utils_ut.rs
+++ b/src/testing/utils_ut.rs
@@ -15,4 +15,13 @@ pub fn test_decimal_to_u128() {
 
     let fractional = Decimal::from_atomics(15u128, 1).unwrap();
     assert_eq!(1, decimal_to_u128(fractional));
+
+    let dec1 = Decimal::from_atomics(600u128, 0).unwrap();
+    assert_eq!(600, decimal_to_u128(dec1));
+
+    let dec1 = Decimal::from_atomics(600u128, 1).unwrap();
+    assert_eq!(60, decimal_to_u128(dec1));
+
+    let dec1 = Decimal::from_atomics(600u128, 3).unwrap();
+    assert_eq!(0, decimal_to_u128(dec1));
 }

--- a/src/testing/utils_ut.rs
+++ b/src/testing/utils_ut.rs
@@ -1,0 +1,18 @@
+use cosmwasm_std::Decimal;
+
+use crate::utils::decimal_to_u128;
+
+#[test]
+pub fn test_decimal_to_u128() {
+    let one = Decimal::one();
+    assert_eq!(1, decimal_to_u128(one));
+
+    let zero = Decimal::zero();
+    assert_eq!(0, decimal_to_u128(zero));
+
+    let ten = Decimal::from_atomics(10u128, 0).unwrap();
+    assert_eq!(10, decimal_to_u128(ten));
+
+    let fractional = Decimal::from_atomics(15u128, 1).unwrap();
+    assert_eq!(1, decimal_to_u128(fractional));
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,1 +1,7 @@
+use cosmwasm_std::Decimal;
 
+pub fn decimal_to_u128(decimal: Decimal) -> u128 {
+    let atomics = decimal.atomics().u128();
+    let denominator = 10u128.pow(decimal.decimal_places()) as u128;
+    atomics / denominator
+}


### PR DESCRIPTION
- when a buy settles, we deduct from withheld price balance and order, and then send asset denom to user's bank. Note that we don't increment balance state for asset denom because the settled asset shouldn't be locked in spot contract.
- when a sell settles, we deduct from withheld asset balance and order, and then send price denom to user's bank. Same reason as above why we don't increment balance state for price.