### PR TITLE
Fix deployment script denom issue

### DIFF
--- a/scripts/deployment/data/register_pair_proposal.json
+++ b/scripts/deployment/data/register_pair_proposal.json
@@ -3,37 +3,37 @@
     "description": "Register initial pairs for Spot",
     "batch_contract_pair": [
         {
-            "contract_addr": "sei1nye7j724mz8vr3es93t0u8lryet0qd6sha95yqzulhad8kwkg7rs0u3slu",
+            "contract_addr": "sei1maqs3qvslrjaq8xz9402shucnr4wzdujty8lr7ux5z5rnj989lwsgjlwd3",
             "pairs": [
                 {
-                    "price_denom": "USDC",
-                    "asset_denom": "ATOM",
+                    "price_denom": "uusdc",
+                    "asset_denom": "uatom",
                     "tick_size": "0.0000001"
                 },
                 {
-                    "price_denom": "USDC",
-                    "asset_denom": "BTC",
+                    "price_denom": "uusdc",
+                    "asset_denom": "ubtc",
                     "tick_size": "0.0000001"
                 },
                 {
-                    "price_denom": "USDC",
-                    "asset_denom": "ETH",
+                    "price_denom": "uusdc",
+                    "asset_denom": "ueth",
                     "tick_size": "0.0000001"
                 },
                 {
-                    "price_denom": "USDC",
-                    "asset_denom": "OSMO",
+                    "price_denom": "uusdc",
+                    "asset_denom": "uosmo",
                     "tick_size": "0.0000001"
                 },
                 {
-                    "price_denom": "USDC",
-                    "asset_denom": "SOL",
+                    "price_denom": "uusdc",
+                    "asset_denom": "usol",
                     "tick_size": "0.0000001"
                 },
                 {
-                    "price_denom": "USDC",
-                            "asset_denom": "SEI",
-                            "tick_size": "0.0000001"
+                    "price_denom": "uusdc",
+                    "asset_denom": "usei",
+                    "tick_size": "0.0000001"
                 }
             ]
         }

--- a/scripts/deployment/spot_deploy.sh
+++ b/scripts/deployment/spot_deploy.sh
@@ -10,13 +10,6 @@ echo -n Keyring Password:\(12345678 by default\)
 read password
 echo
 
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-  printf "OS is linux"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-  printf "OS is Mac"
-  sed_flag=\'\'
-fi
-
 if [ -z "${contract}" ];
 then contract=../../artifacts/spot_lite.wasm
 fi 
@@ -29,23 +22,31 @@ fi
 
 seid=~/go/bin/seid
 code=$(printf $password | $seid tx wasm store $contract -y --from=$keyname --chain-id=sei-chain --gas=10000000 --fees=10000000usei --broadcast-mode=block | grep -A 1 "code_id" | sed -n 's/.*value: "//p' | sed -n 's/"//p')
-admin_addr=$(printf $password |$seid keys show admin | grep -A 1 "address" | sed -n 's/.*address: //p')
+admin_addr=$(printf $password |$seid keys show $keyname | grep -A 1 "address" | sed -n 's/.*address: //p')
 
-addr=$(printf $password |$seid tx wasm instantiate $code "{}" --from admin --broadcast-mode=block --label "spot" --no-admin --chain-id sei-chain --gas=30000000 --fees=300000usei -y | grep -A 1 -m 1 "key: _contract_address" | sed -n 's/.*value: //p' | xargs)
+addr=$(printf $password |$seid tx wasm instantiate $code "{}" --from $keyname --broadcast-mode=block --label "spot" --no-admin --chain-id sei-chain --gas=30000000 --fees=300000usei -y | grep -A 1 -m 1 "key: _contract_address" | sed -n 's/.*value: //p' | xargs)
 
-sed -i $sed_flag "s/\"contract_addr\": .*,/\"contract_addr\": \"$addr\",/g" data/register_pair_proposal.json
-printf $password |$seid tx dex register-contract $addr $code false -y --from=$keyname --chain-id=sei-chain --fees=10000000usei --gas=10000000 --broadcast-mode=block
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  printf "OS is linux"
+  sed -i "s/\"contract_addr\": .*,/\"contract_addr\": \"$addr\",/g" data/register_pair_proposal.json
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  printf "OS is Mac"
+  sed -i '' "s/\"contract_addr\": .*,/\"contract_addr\": \"$addr\",/g" data/register_pair_proposal.json
+fi
+
+printf $password |$seid tx dex register-contract $addr $code false true -y --from=$keyname --chain-id=sei-chain --fees=10000000usei --gas=10000000 --broadcast-mode=block
 proposal_id=$(printf $password |$seid tx dex register-pairs-proposal data/register_pair_proposal.json -y --from=$keyname --chain-id=sei-chain --fees=10000000usei --gas=500000 --broadcast-mode=block | grep -A 1 -m 1 "proposal_id" | sed -n 's/.*value: "//p' | sed -n 's/"//p')
-printf $password |$seid tx gov deposit $proposal_id 10000000usei -y --from=admin --chain-id=sei-chain --fees=10000000usei --gas=500000 --broadcast-mode=block
-printf $password |$seid tx gov vote $proposal_id yes -y --from=admin --chain-id=sei-chain --fees=2000usei --gas=500000 --broadcast-mode=block
+printf $password |$seid tx gov deposit $proposal_id 10000000usei -y --from=$keyname --chain-id=sei-chain --fees=10000000usei --gas=500000 --broadcast-mode=block
+printf $password |$seid tx gov vote $proposal_id yes -y --from=$keyname --chain-id=sei-chain --fees=2000usei --gas=500000 --broadcast-mode=block
 
 # sleep 10 second and send a test order to USDC<>ATOM pair
 printf "\n\nWaiting for the proposal to pass"
 sleep 10
-printf $password |$seid tx dex place-orders $addr 'LONG?1.01?50?USDC?ATOM?LIMIT?{"leverage":"1","position_effect":"Open"}' --amount=10000000000uusdc -y --from=$keyname --chain-id=sei-chain --fees=1000000usei --gas=50000000 --broadcast-mode=block
-printf $password |$seid tx dex place-orders $addr 'LONG?1.01?50?USDC?ATOM?LIMIT?{"leverage":"1","position_effect":"Open"}' --amount=10000000000uusdc -y --from=$keyname --chain-id=sei-chain --fees=1000000usei --gas=50000000 --broadcast-mode=block
-printf $password |$seid tx dex place-orders $addr 'SHORT?1.51?50?USDC?ATOM?LIMIT?{"leverage":"1","position_effect":"Open"}' --amount=10000000000uusdc -y --from=$keyname --chain-id=sei-chain --fees=1000000usei --gas=50000000 --broadcast-mode=block
-printf $password |$seid tx dex place-orders $addr 'SHORT?1.51?50?USDC?ATOM?LIMIT?{"leverage":"1","position_effect":"Open"}' --amount=10000000000uusdc -y --from=$keyname --chain-id=sei-chain --fees=1000000usei --gas=50000000 --broadcast-mode=block
-printf $password |$seid q dex list-long-book $addr USDC ATOM
+printf $password |$seid tx dex place-orders $addr 'LONG?1.01?50?uusdc?uatom?LIMIT?{"leverage":"1","position_effect":"Open"}' --amount=10000000000uusdc -y --from=$keyname --chain-id=sei-chain --fees=1000000usei --gas=50000000 --broadcast-mode=block
+printf $password |$seid tx dex place-orders $addr 'LONG?1.01?50?uusdc?uatom?LIMIT?{"leverage":"1","position_effect":"Open"}' --amount=10000000000uusdc -y --from=$keyname --chain-id=sei-chain --fees=1000000usei --gas=50000000 --broadcast-mode=block
+printf $password |$seid tx dex place-orders $addr 'SHORT?1.51?50?uusdc?uatom?LIMIT?{"leverage":"1","position_effect":"Open"}' --amount=10000000000uatom -y --from=$keyname --chain-id=sei-chain --fees=1000000usei --gas=50000000 --broadcast-mode=block
+printf $password |$seid tx dex place-orders $addr 'SHORT?1.51?50?uusdc?uatom?LIMIT?{"leverage":"1","position_effect":"Open"}' --amount=10000000000uatom -y --from=$keyname --chain-id=sei-chain --fees=1000000usei --gas=50000000 --broadcast-mode=block
+printf $password |$seid q dex list-long-book $addr uusdc uatom
 
 printf "\n\nDeployed spot contract address is %s\n" $addr


### PR DESCRIPTION
This PR fixes the following issues:
- spot denom should be micro (i.e. uusdc instead of USDC) for both token pair denom and deposit denom
- replace hardcoded admin with custom keyring name